### PR TITLE
Increment chart argo-test/app2 version: 1.10.0 --> 1.11.0 [skip ci]

### DIFF
--- a/argo-test/app2/Chart.yaml
+++ b/argo-test/app2/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.0
+version: 1.11.0
  
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Increment chart argo-test/app2 version: 1.10.0 --> 1.11.0 [skip ci]